### PR TITLE
fix: Add MUI dependencies and remove Tailwind

### DIFF
--- a/inventory-frontend/package.json
+++ b/inventory-frontend/package.json
@@ -10,14 +10,14 @@
     "preview": "vite preview"
   },
   "dependencies": {
-    "@heroicons/react": "^2.2.0",
-    "autoprefixer": "^10.4.21",
-    "postcss": "^8.5.6",
+    "@emotion/react": "^11.11.4",
+    "@emotion/styled": "^11.11.5",
+    "@mui/icons-material": "^5.15.20",
+    "@mui/material": "^5.15.20",
     "react": "^19.1.1",
     "react-dom": "^19.1.1",
     "react-router-dom": "^7.8.0",
-    "recharts": "^3.1.2",
-    "tailwindcss": "^4.1.11"
+    "recharts": "^3.1.2"
   },
   "devDependencies": {
     "@eslint/js": "^9.32.0",


### PR DESCRIPTION
This commit updates the `package.json` file to correctly include the dependencies for Material UI (@mui/material, @mui/icons-material, @emotion/react, @emotion/styled).

It also removes the old, unused dependencies related to the previous TailwindCSS implementation.

This is a critical fix to resolve the 'Failed to resolve import' error when running the application.