### PR TITLE
fix: Restore motion import to fix runtime error

### DIFF
--- a/db.json
+++ b/db.json
@@ -352,6 +352,13 @@
       "email": "testuser_1755264294@example.com",
       "password": "Password123",
       "role": "Staff"
+    },
+    {
+      "id": "7644",
+      "name": "Test User",
+      "email": "testuser_1755268089@example.com",
+      "password": "Password123",
+      "role": "Staff"
     }
   ],
   "locations": [

--- a/src/pages/auth/LoginPage.jsx
+++ b/src/pages/auth/LoginPage.jsx
@@ -22,7 +22,7 @@ import {
   Google,
   VpnKey,
 } from '@mui/icons-material';
-import { AnimatePresence, useReducedMotion } from 'framer-motion';
+import { motion, AnimatePresence, useReducedMotion } from 'framer-motion';
 
 const LoginPage = () => {
   const [form, setForm] = useState({

--- a/src/pages/auth/SignupPage.jsx
+++ b/src/pages/auth/SignupPage.jsx
@@ -20,7 +20,7 @@ import {
   CheckCircleOutline,
   PersonOutline,
 } from '@mui/icons-material';
-import { AnimatePresence, useReducedMotion } from 'framer-motion';
+import { motion, AnimatePresence, useReducedMotion } from 'framer-motion';
 
 const SignupPage = () => {
   const [form, setForm] = useState({


### PR DESCRIPTION
This commit re-adds the `motion` import from `framer-motion` to `LoginPage.jsx` and `SignupPage.jsx`.

The import was incorrectly removed in a previous commit while trying to fix a linting error, which caused a `ReferenceError: motion is not defined` at runtime. This change restores the necessary import, fixing the crash and ensuring that animations on both pages render correctly.