### PR TITLE
Fix: Correct AppDialog prop from isOpen to open

### DIFF
--- a/src/pages/customers/CustomersPage.jsx
+++ b/src/pages/customers/CustomersPage.jsx
@@ -104,7 +104,7 @@ const CustomersPage = () => {
       <MuiTable headers={tableHeaders} data={tableData} />
 
       <AppDialog
-        isOpen={isFormOpen}
+        open={isFormOpen}
         onClose={handleCloseForm}
         title={customerToEdit ? 'Edit Customer' : 'Add New Customer'}
       >

--- a/src/pages/products/ProductsPage.jsx
+++ b/src/pages/products/ProductsPage.jsx
@@ -149,7 +149,7 @@ const ProductsPage = () => {
       <MuiTable headers={tableHeaders} data={tableData} />
 
       <AppDialog
-        isOpen={isFormOpen}
+        open={isFormOpen}
         onClose={handleCloseForm}
         title={productToEdit ? 'Edit Product' : 'Add New Product'}
       >

--- a/src/pages/sales/SalesOrdersPage.jsx
+++ b/src/pages/sales/SalesOrdersPage.jsx
@@ -124,7 +124,7 @@ const SalesOrdersPage = () => {
       />
 
       <AppDialog
-        isOpen={isDetailsOpen}
+        open={isDetailsOpen}
         onClose={() => setIsDetailsOpen(false)}
         title={`Details for SO #${soToView?.id}`}
       >

--- a/src/pages/stock/StockPage.jsx
+++ b/src/pages/stock/StockPage.jsx
@@ -141,7 +141,7 @@ const StockPage = () => {
 
       {selectedProduct && (
         <AppDialog
-          isOpen={isAdjustmentModalOpen}
+          open={isAdjustmentModalOpen}
           onClose={handleCloseAdjustmentModal}
           title={`Adjust Stock for ${selectedProduct.name}`}
         >
@@ -151,7 +151,7 @@ const StockPage = () => {
 
       {selectedProduct && (
         <AppDialog
-          isOpen={isTransferModalOpen}
+          open={isTransferModalOpen}
           onClose={handleCloseTransferModal}
           title={`Transfer Stock for ${selectedProduct.name}`}
         >
@@ -161,7 +161,7 @@ const StockPage = () => {
 
       {selectedProduct && (
         <AppDialog
-          isOpen={isDetailsModalOpen}
+          open={isDetailsModalOpen}
           onClose={handleCloseDetailsModal}
           title={`Stock Details for ${selectedProduct.name}`}
           maxWidth="md"

--- a/src/pages/suppliers/SuppliersPage.jsx
+++ b/src/pages/suppliers/SuppliersPage.jsx
@@ -125,7 +125,7 @@ const SuppliersPage = () => {
       <MuiTable headers={tableHeaders} data={tableData || []} />
 
       <AppDialog
-        isOpen={isFormOpen}
+        open={isFormOpen}
         onClose={handleCloseForm}
         title={supplierToEdit ? 'Edit Supplier' : 'Add New Supplier'}
       >


### PR DESCRIPTION
The AppDialog component expects an `open` prop to control its visibility, but several pages were using `isOpen` instead. This caused the dialogs on those pages, including the "Add Product" dialog, to not open when triggered.

This commit replaces all incorrect instances of `isOpen` with the correct `open` prop in the following files:
- src/pages/products/ProductsPage.jsx
- src/pages/customers/CustomersPage.jsx
- src/pages/sales/SalesOrdersPage.jsx
- src/pages/stock/StockPage.jsx
- src/pages/suppliers/SuppliersPage.jsx