### PR TITLE
feat: Add CSV import for products

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -19,6 +19,7 @@
         "framer-motion": "^11.0.14",
         "jspdf": "^3.0.1",
         "jspdf-autotable": "^5.0.2",
+        "papaparse": "^5.5.3",
         "react": "^19.1.1",
         "react-dom": "^19.1.1",
         "react-intersection-observer": "^9.16.0",
@@ -4177,6 +4178,12 @@
       "funding": {
         "url": "https://github.com/sponsors/sindresorhus"
       }
+    },
+    "node_modules/papaparse": {
+      "version": "5.5.3",
+      "resolved": "https://registry.npmjs.org/papaparse/-/papaparse-5.5.3.tgz",
+      "integrity": "sha512-5QvjGxYVjxO59MGU2lHVYpRWBBtKHnlIAcSe1uNFCkkptUh63NFRj0FJQm7nR67puEruUci/ZkjmEFrjCAyP4A==",
+      "license": "MIT"
     },
     "node_modules/parent-module": {
       "version": "1.0.1",

--- a/package.json
+++ b/package.json
@@ -22,6 +22,7 @@
     "framer-motion": "^11.0.14",
     "jspdf": "^3.0.1",
     "jspdf-autotable": "^5.0.2",
+    "papaparse": "^5.5.3",
     "react": "^19.1.1",
     "react-dom": "^19.1.1",
     "react-intersection-observer": "^9.16.0",

--- a/src/App.jsx
+++ b/src/App.jsx
@@ -4,6 +4,7 @@ import LoginPage from './pages/auth/LoginPage';
 import SignupPage from './pages/auth/SignupPage';
 import DashboardPage from './pages/dashboard/DashboardPage';
 import ProductsPage from './pages/products/ProductsPage';
+import ProductImportPage from './pages/products/ProductImportPage';
 import StockPage from './pages/stock/StockPage';
 import SuppliersPage from './pages/suppliers/SuppliersPage';
 import ReportsLayout from './pages/reports/ReportsLayout';
@@ -36,6 +37,7 @@ function App() {
           <Route element={<PrivateRoute roles={['Admin', 'Manager', 'Staff', 'user']} />}>
             <Route path="/dashboard" element={<DashboardPage />} />
             <Route path="/products" element={<ProductsPage />} />
+            <Route path="/products/import" element={<ProductImportPage />} />
             <Route path="/stock" element={<StockPage />} />
             <Route path="/purchase-orders" element={<PurchaseOrdersPage />} />
           </Route>

--- a/src/pages/products/ProductImportPage.jsx
+++ b/src/pages/products/ProductImportPage.jsx
@@ -1,0 +1,182 @@
+import React, { useState } from 'react';
+import {
+  Box,
+  Button,
+  Container,
+  Paper,
+  Typography,
+  Alert,
+  List,
+  ListItem,
+  ListItemIcon,
+  ListItemText,
+  CircularProgress
+} from '@mui/material';
+import { UploadFile as UploadFileIcon, Description as DescriptionIcon } from '@mui/icons-material';
+import Papa from 'papaparse';
+import { useApi } from '../../utils/ApiModeContext';
+import { useMutation, useQueryClient } from '@tanstack/react-query';
+import { useNotification } from '../../utils/NotificationContext';
+
+const ProductImportPage = () => {
+  const [csvFile, setCsvFile] = useState(null);
+  const [isProcessing, setIsProcessing] = useState(false);
+  const [importResults, setImportResults] = useState(null);
+  const { services } = useApi();
+  const queryClient = useQueryClient();
+  const showNotification = useNotification();
+
+  const mutation = useMutation({
+    mutationFn: (newProduct) => services.products.createProduct(newProduct),
+    onSuccess: () => {
+      queryClient.invalidateQueries(['products']);
+    },
+    onError: (error) => {
+      // This will be part of a more detailed error report
+      console.error("Failed to import product:", error);
+    }
+  });
+
+  const handleFileChange = (event) => {
+    setCsvFile(event.target.files[0]);
+    setImportResults(null);
+  };
+
+  const handleImport = () => {
+    if (!csvFile) {
+      showNotification('Please select a CSV file to import.', 'error');
+      return;
+    }
+
+    setIsProcessing(true);
+    setImportResults(null);
+
+    Papa.parse(csvFile, {
+      header: true,
+      skipEmptyLines: true,
+      complete: async (results) => {
+        const { data, errors } = results;
+        let successfulImports = 0;
+        let failedImports = 0;
+        const importErrors = [];
+
+        if (errors.length > 0) {
+            importErrors.push(...errors.map(e => `Parsing error on row ${e.row}: ${e.message}`));
+        }
+
+        for (const row of data) {
+          try {
+            // Basic validation
+            if (!row.name || !row.price || !row.sku) {
+                throw new Error(`Missing required fields (name, price, sku)`);
+            }
+            const newProduct = {
+              name: row.name,
+              sku: row.sku,
+              barcode: row.barcode || '',
+              category: row.category || 'Uncategorized',
+              price: parseFloat(row.price),
+              costPrice: parseFloat(row.costPrice) || 0,
+              lowStockThreshold: parseInt(row.lowStockThreshold, 10) || 0,
+            };
+            await mutation.mutateAsync(newProduct);
+            successfulImports++;
+          } catch (error) {
+            failedImports++;
+            importErrors.push(`Failed to import product "${row.name || 'Unknown'}": ${error.message}`);
+          }
+        }
+
+        setImportResults({ successfulImports, failedImports, importErrors });
+        setIsProcessing(false);
+        if(successfulImports > 0) {
+            showNotification(`${successfulImports} products imported successfully!`, 'success');
+        }
+        if(failedImports > 0) {
+            showNotification(`${failedImports} products failed to import. See details on page.`, 'error');
+        }
+      },
+      error: (error) => {
+        showNotification(`Error parsing CSV file: ${error.message}`, 'error');
+        setIsProcessing(false);
+      }
+    });
+  };
+
+  return (
+    <Container maxWidth="md">
+      <Paper sx={{ p: 4, mt: 4 }}>
+        <Typography variant="h4" gutterBottom>
+          Import Products from CSV
+        </Typography>
+        <Typography paragraph>
+          Upload a CSV file to bulk-import products into the system. The file should have the following columns:
+        </Typography>
+        <List dense>
+            <ListItem><ListItemText primary="name (Required): The name of the product." /></ListItem>
+            <ListItem><ListItemText primary="sku (Required): The Stock Keeping Unit." /></ListItem>
+            <ListItem><ListItemText primary="price (Required): The selling price." /></ListItem>
+            <ListItem><ListItemText primary="costPrice: The cost of the product." /></ListItem>
+            <ListItem><ListItemText primary="category: The product category." /></ListItem>
+            <ListItem><ListItemText primary="barcode: The product's barcode." /></ListItem>
+            <ListItem><ListItemText primary="lowStockThreshold: The low stock warning level." /></ListItem>
+        </List>
+
+        <Box sx={{ mt: 3, mb: 2, p: 3, border: '1px dashed grey', borderRadius: '4px', textAlign: 'center' }}>
+          <Button
+            variant="contained"
+            component="label"
+            startIcon={<UploadFileIcon />}
+          >
+            Select CSV File
+            <input
+              type="file"
+              hidden
+              accept=".csv"
+              onChange={handleFileChange}
+            />
+          </Button>
+          {csvFile && (
+            <Typography sx={{ mt: 2 }} display="flex" alignItems="center" justifyContent="center">
+              <DescriptionIcon sx={{ mr: 1 }} /> {csvFile.name}
+            </Typography>
+          )}
+        </Box>
+
+        <Button
+          variant="contained"
+          color="primary"
+          onClick={handleImport}
+          disabled={!csvFile || isProcessing}
+          fullWidth
+          sx={{ mt: 2, py: 1.5 }}
+        >
+          {isProcessing ? <CircularProgress size={24} /> : 'Start Import'}
+        </Button>
+
+        {importResults && (
+            <Box sx={{ mt: 4 }}>
+                <Typography variant="h6">Import Summary</Typography>
+                <Alert severity={importResults.failedImports === 0 ? 'success' : 'warning'}>
+                    Successfully imported {importResults.successfulImports} products.
+                    <br />
+                    Failed to import {importResults.failedImports} products.
+                </Alert>
+                {importResults.importErrors.length > 0 && (
+                    <Paper sx={{p: 2, mt: 2, maxHeight: 300, overflow: 'auto' }}>
+                        <Typography variant="subtitle1" color="error">Error Details:</Typography>
+                        <List dense>
+                            {importResults.importErrors.map((error, index) => (
+                                <ListItem key={index}><ListItemText primary={error} /></ListItem>
+                            ))}
+                        </List>
+                    </Paper>
+                )}
+            </Box>
+        )}
+      </Paper>
+    </Container>
+  );
+};
+
+export default ProductImportPage;

--- a/src/pages/products/ProductsPage.jsx
+++ b/src/pages/products/ProductsPage.jsx
@@ -3,6 +3,7 @@ import { useQuery, useMutation, useQueryClient } from '@tanstack/react-query';
 import { useApi } from '../../utils/ApiModeContext';
 import { useNotification } from '../../utils/NotificationContext';
 import { Parser } from '@json2csv/plainjs';
+import { useNavigate } from 'react-router-dom';
 
 import MuiTable from '../../components/ui/Table';
 import SearchBar from '../../components/ui/SearchBar';
@@ -19,12 +20,14 @@ import IconButton from '@mui/material/IconButton';
 import EditIcon from '@mui/icons-material/Edit';
 import DeleteIcon from '@mui/icons-material/Delete';
 import DownloadIcon from '@mui/icons-material/Download';
+import UploadFileIcon from '@mui/icons-material/UploadFile';
 import Stack from '@mui/material/Stack';
 
 const ProductsPage = () => {
   const queryClient = useQueryClient();
   const { showNotification } = useNotification();
   const { mode, services } = useApi();
+  const navigate = useNavigate();
 
   const [searchQuery, setSearchQuery] = useState('');
   const [isFormOpen, setIsFormOpen] = useState(false);
@@ -129,14 +132,21 @@ const ProductsPage = () => {
     <div>
       <Box sx={{ display: 'flex', justifyContent: 'space-between', alignItems: 'center', mb: 2 }}>
         <Typography variant="h4">Products</Typography>
-        <Stack direction="row" spacing={2}>
+        <Stack direction="row" spacing={1}>
+          <Button
+            variant="outlined"
+            startIcon={<UploadFileIcon />}
+            onClick={() => navigate('/products/import')}
+          >
+            Import
+          </Button>
           <Button
             variant="outlined"
             startIcon={<DownloadIcon />}
             onClick={handleExport}
             disabled={!filteredProducts || filteredProducts.length === 0}
           >
-            Export as CSV
+            Export
           </Button>
           <Button variant="contained" onClick={handleAddClick}>Add Product</Button>
         </Stack>


### PR DESCRIPTION
- Adds a new page to allow users to upload a CSV file with product data.
- Integrates `papaparse` for robust CSV parsing.
- Provides feedback on the import process, including success and error summaries.
- Adds a link to the import page from the main product listing.