### PR TITLE
This commit introduces the ability to display images for products.

### DIFF
--- a/db.json
+++ b/db.json
@@ -1,13 +1,13 @@
 {
   "products": [
-    { "id": 1, "name": "Wireless Mouse", "sku": "WM-001", "category": "Electronics", "price": 25.99, "costPrice": 15.50, "lowStockThreshold": 20, "createdAt": "2024-11-10T10:00:00Z", "barcode": "8901234567890" },
-    { "id": 2, "name": "Mechanical Keyboard", "sku": "MK-001", "category": "Electronics", "price": 120.00, "costPrice": 80.00, "lowStockThreshold": 50, "createdAt": "2025-01-15T11:30:00Z", "barcode": "8902345678901" },
-    { "id": 3, "name": "USB-C Hub", "sku": "UCH-001", "category": "Accessories", "price": 45.50, "costPrice": 30.00, "lowStockThreshold": 25, "createdAt": "2025-05-20T14:00:00Z", "barcode": "8903456789012" },
-    { "id": 4, "name": "14\" Laptop Sleeve", "sku": "LS-014", "category": "Accessories", "price": 18.99, "costPrice": 10.00, "lowStockThreshold": 50, "createdAt": "2024-09-05T09:00:00Z", "barcode": "8904567890123" },
-    { "id": 5, "name": "27\" 4K Monitor", "sku": "M-4K-027", "category": "Monitors", "price": 499.99, "costPrice": 350.00, "lowStockThreshold": 50, "createdAt": "2025-07-22T18:00:00Z", "barcode": "8905678901234" },
-    { "id": 6, "name": "Ergonomic Chair", "sku": "EC-001", "category": "Furniture", "price": 299.00, "costPrice": 200.00, "lowStockThreshold": 35, "createdAt": "2024-03-12T12:00:00Z", "barcode": "8906789012345" },
-    { "id": 7, "name": "Standing Desk", "sku": "SD-001", "category": "Furniture", "price": 350.00, "costPrice": 250.00, "lowStockThreshold": 20, "createdAt": "2025-06-30T16:45:00Z", "barcode": "8907890123456" },
-    { "id": 8, "name": "Webcam 1080p", "sku": "WC-1080", "category": "Electronics", "price": 65.00, "costPrice": 40.00, "lowStockThreshold": 100, "createdAt": "2025-08-01T08:00:00Z", "barcode": "8908901234567" }
+    { "id": 1, "name": "Wireless Mouse", "sku": "WM-001", "category": "Electronics", "price": 25.99, "costPrice": 15.50, "lowStockThreshold": 20, "createdAt": "2024-11-10T10:00:00Z", "barcode": "8901234567890", "imageUrl": "https://picsum.photos/seed/1/200" },
+    { "id": 2, "name": "Mechanical Keyboard", "sku": "MK-001", "category": "Electronics", "price": 120.00, "costPrice": 80.00, "lowStockThreshold": 50, "createdAt": "2025-01-15T11:30:00Z", "barcode": "8902345678901", "imageUrl": "https://picsum.photos/seed/2/200" },
+    { "id": 3, "name": "USB-C Hub", "sku": "UCH-001", "category": "Accessories", "price": 45.50, "costPrice": 30.00, "lowStockThreshold": 25, "createdAt": "2025-05-20T14:00:00Z", "barcode": "8903456789012", "imageUrl": "https://picsum.photos/seed/3/200" },
+    { "id": 4, "name": "14\" Laptop Sleeve", "sku": "LS-014", "category": "Accessories", "price": 18.99, "costPrice": 10.00, "lowStockThreshold": 50, "createdAt": "2024-09-05T09:00:00Z", "barcode": "8904567890123", "imageUrl": "" },
+    { "id": 5, "name": "27\" 4K Monitor", "sku": "M-4K-027", "category": "Monitors", "price": 499.99, "costPrice": 350.00, "lowStockThreshold": 50, "createdAt": "2025-07-22T18:00:00Z", "barcode": "8905678901234", "imageUrl": "https://picsum.photos/seed/5/200" },
+    { "id": 6, "name": "Ergonomic Chair", "sku": "EC-001", "category": "Furniture", "price": 299.00, "costPrice": 200.00, "lowStockThreshold": 35, "createdAt": "2024-03-12T12:00:00Z", "barcode": "8906789012345", "imageUrl": "" },
+    { "id": 7, "name": "Standing Desk", "sku": "SD-001", "category": "Furniture", "price": 350.00, "costPrice": 250.00, "lowStockThreshold": 20, "createdAt": "2025-06-30T16:45:00Z", "barcode": "8907890123456", "imageUrl": "https://picsum.photos/seed/7/200" },
+    { "id": 8, "name": "Webcam 1080p", "sku": "WC-1080", "category": "Electronics", "price": 65.00, "costPrice": 40.00, "lowStockThreshold": 100, "createdAt": "2025-08-01T08:00:00Z", "barcode": "8908901234567", "imageUrl": "https://picsum.photos/seed/8/200" }
   ],
   "suppliers": [
     { "id": 1, "name": "ElectroSupply", "contact": "John Doe", "email": "john.doe@electrosupply.com", "products": [1, 2, 8] },

--- a/src/pages/products/AddEditProductForm.jsx
+++ b/src/pages/products/AddEditProductForm.jsx
@@ -31,6 +31,7 @@ const AddEditProductForm = ({
     price: '',
     costPrice: '',
     lowStockThreshold: '',
+    imageUrl: '',
     stock: '',
     batchNumber: '',
     expiryDate: '',
@@ -55,6 +56,7 @@ const AddEditProductForm = ({
         price: product.price || '',
         costPrice: product.costPrice || '',
         lowStockThreshold: product.lowStockThreshold || '',
+        imageUrl: product.imageUrl || '',
         stock: '',
         batchNumber: '',
         expiryDate: '',
@@ -134,6 +136,7 @@ const AddEditProductForm = ({
       <TextField margin="dense" id="price" name="price" label="Price" type="number" fullWidth variant="standard" value={formData.price} onChange={handleChange} required />
       <TextField margin="dense" id="costPrice" name="costPrice" label="Cost Price" type="number" fullWidth variant="standard" value={formData.costPrice} onChange={handleChange} required />
       <TextField margin="dense" id="lowStockThreshold" name="lowStockThreshold" label="Low Stock Threshold" type="number" fullWidth variant="standard" value={formData.lowStockThreshold} onChange={handleChange} required />
+      <TextField margin="dense" id="imageUrl" name="imageUrl" label="Image URL" type="text" fullWidth variant="standard" value={formData.imageUrl} onChange={handleChange} />
 
       {!isEditMode && (
         <>

--- a/src/pages/products/ProductsPage.jsx
+++ b/src/pages/products/ProductsPage.jsx
@@ -103,9 +103,14 @@ const ProductsPage = () => {
     setProductToEdit(null);
   }
 
-  const tableHeaders = ['Name', 'SKU', 'Barcode', 'Category', 'Price', 'Stock', 'Actions'];
+  const tableHeaders = ['Image', 'Name', 'SKU', 'Barcode', 'Category', 'Price', 'Stock', 'Actions'];
 
   const tableData = filteredProducts.map(p => ({
+    image: p.imageUrl ? (
+      <img src={p.imageUrl} alt={p.name} style={{ width: 50, height: 50, objectFit: 'cover', borderRadius: '4px' }} />
+    ) : (
+      <Box sx={{ width: 50, height: 50, backgroundColor: '#f0f0f0', borderRadius: '4px' }} />
+    ),
     name: p.name,
     sku: p.sku,
     barcode: p.barcode,


### PR DESCRIPTION
This addresses the user's request to implement the first of the 10 feature ideas suggested for improving the product page.

Changes include:
- Extended the product data model in `db.json` to include an `imageUrl` field.
- Updated the 'Add/Edit Product' form to include a field for the image URL.
- Modified the products table to display a thumbnail of the product image.
- Added a placeholder for products without an image.