### PR TITLE
Fix(stock): Resolve unique key warning in stock table

### DIFF
--- a/src/components/ui/Table.jsx
+++ b/src/components/ui/Table.jsx
@@ -11,7 +11,7 @@ import Box from '@mui/material/Box';
 import { visuallyHidden } from '@mui/utils';
 
 const MuiTable = ({ headers, data, onSort, sortColumn, sortDirection }) => {
-  const createSortHandler = (property) => (event) => {
+  const createSortHandler = (property) => () => {
     onSort(property);
   };
 
@@ -49,13 +49,13 @@ const MuiTable = ({ headers, data, onSort, sortColumn, sortDirection }) => {
           </TableRow>
         </TableHead>
         <TableBody>
-          {data.map((row, rowIndex) => (
+          {data.map((row) => (
             <TableRow
-              key={rowIndex}
+              key={row.id}
               sx={{ '&:last-child td, &:last-child th': { border: 0 } }}
             >
               {headers.map(header => (
-                <TableCell key={header.id}>
+                <TableCell key={header.id} align={header.numeric ? 'right' : 'left'}>
                   {row[header.id]}
                 </TableCell>
               ))}

--- a/src/pages/stock/StockPage.jsx
+++ b/src/pages/stock/StockPage.jsx
@@ -80,9 +80,16 @@ const StockPage = () => {
     }
   };
 
-  const tableHeaders = ['Name', 'SKU', 'Total Stock', 'Status', 'Actions'];
+  const tableHeaders = [
+    { id: 'name', label: 'Name' },
+    { id: 'sku', label: 'SKU' },
+    { id: 'quantity', label: 'Total Stock' },
+    { id: 'status', label: 'Status' },
+    { id: 'actions', label: 'Actions' },
+  ];
 
   const tableData = stockLevels?.map(p => ({
+    id: p.id,
     name: p.name,
     sku: p.sku,
     quantity: p.stock,


### PR DESCRIPTION
This commit addresses a React warning about missing unique keys on the stock management page. The root cause was twofold:
1. The `MuiTable` component was using the row index as a key, which is not ideal for dynamic lists.
2. The `StockPage` was passing an array of strings for headers instead of an array of objects with `id` and `label` properties, as expected by the `MuiTable` component.

The following changes have been made:
- `src/pages/stock/StockPage.jsx`: The `tableHeaders` are now correctly formatted as an array of objects. The `id` of each product is now passed in the `tableData`.
- `src/components/ui/Table.jsx`: The `TableRow` key is now set to `row.id`, ensuring a unique and stable identifier for each row. A minor linting issue was also fixed.

While the user initially suspected duplicate data in `public/db.json`, an investigation revealed the data to be clean. The issue was purely in the frontend component implementation.