### PR TITLE
Fix(table): Update all MuiTable usage to prevent key warnings

### DIFF
--- a/src/pages/billing/BillingPage.jsx
+++ b/src/pages/billing/BillingPage.jsx
@@ -27,10 +27,18 @@ const BillingPage = () => {
     queryFn: () => services.invoices.getInvoices(), // This function needs to be created
   });
 
-  const tableHeaders = ['Invoice ID', 'Customer', 'Invoice Date', 'Due Date', 'Status', 'Total', 'Actions'];
+  const tableHeaders = [
+    { id: 'id', label: 'Invoice ID' },
+    { id: 'customerName', label: 'Customer' },
+    { id: 'invoiceDate', label: 'Invoice Date' },
+    { id: 'dueDate', label: 'Due Date' },
+    { id: 'status', label: 'Status' },
+    { id: 'total', label: 'Total' },
+    { id: 'actions', label: 'Actions' },
+  ];
 
   const tableData = invoices.map((invoice) => ({
-    id: `#${invoice.id}`,
+    id: invoice.id,
     customerName: invoice.customerName,
     invoiceDate: new Date(invoice.invoiceDate).toLocaleDateString(),
     dueDate: new Date(invoice.dueDate).toLocaleDateString(),

--- a/src/pages/customers/CustomersPage.jsx
+++ b/src/pages/customers/CustomersPage.jsx
@@ -71,9 +71,16 @@ const CustomersPage = () => {
     setCustomerToEdit(null);
   };
 
-  const tableHeaders = ['Name', 'Email', 'Phone', 'Address', 'Actions'];
+  const tableHeaders = [
+    { id: 'name', label: 'Name' },
+    { id: 'email', label: 'Email' },
+    { id: 'phone', label: 'Phone' },
+    { id: 'address', label: 'Address' },
+    { id: 'actions', label: 'Actions' },
+  ];
 
   const tableData = customers.map((customer) => ({
+    id: customer.id,
     name: customer.name,
     email: customer.email,
     phone: customer.phone,

--- a/src/pages/orders/PurchaseOrdersPage.jsx
+++ b/src/pages/orders/PurchaseOrdersPage.jsx
@@ -126,7 +126,15 @@ const PurchaseOrdersPage = () => {
     document.body.removeChild(link);
   };
 
-  const tableHeaders = ['PO ID', 'Supplier', 'Date', 'Total Value', 'Status', 'Items', 'Actions'];
+  const tableHeaders = [
+    { id: 'id', label: 'PO ID' },
+    { id: 'supplier', label: 'Supplier' },
+    { id: 'date', label: 'Date' },
+    { id: 'totalValue', label: 'Total Value' },
+    { id: 'status', label: 'Status' },
+    { id: 'itemCount', label: 'Items' },
+    { id: 'actions', label: 'Actions' },
+  ];
 
   const tableData = purchaseOrders?.map(po => {
     const totalValue = productsLoaded ? po.products.reduce((acc, item) => {

--- a/src/pages/reports/StockExpiryReport.jsx
+++ b/src/pages/reports/StockExpiryReport.jsx
@@ -25,9 +25,16 @@ const StockExpiryReport = () => {
     )
     .sort((a, b) => a.expiryDate - b.expiryDate);
 
-  const tableHeaders = ['Product Name', 'SKU', 'Batch Number', 'Quantity', 'Expiry Date'];
+  const tableHeaders = [
+    { id: 'productName', label: 'Product Name' },
+    { id: 'productSku', label: 'SKU' },
+    { id: 'batchNumber', label: 'Batch Number' },
+    { id: 'quantity', label: 'Quantity' },
+    { id: 'expiryDate', label: 'Expiry Date' },
+  ];
 
   const tableData = reportData.map(item => ({
+    id: `${item.productSku}-${item.batchNumber}`,
     productName: item.productName,
     productSku: item.productSku,
     batchNumber: item.batchNumber,

--- a/src/pages/sales/SalesOrdersPage.jsx
+++ b/src/pages/sales/SalesOrdersPage.jsx
@@ -104,7 +104,14 @@ const SalesOrdersPage = () => {
     generateInvoiceMutation.mutate(newInvoice);
   };
 
-  const tableHeaders = ['SO ID', 'Customer', 'Date', 'Status', 'Total', 'Actions'];
+  const tableHeaders = [
+    { id: 'id', label: 'SO ID' },
+    { id: 'customerName', label: 'Customer' },
+    { id: 'createdAt', label: 'Date' },
+    { id: 'status', label: 'Status' },
+    { id: 'total', label: 'Total' },
+    { id: 'actions', label: 'Actions' },
+  ];
 
   const tableData = salesOrders.map((so) => ({
     id: so.id,

--- a/src/pages/settings/LocationsPage.jsx
+++ b/src/pages/settings/LocationsPage.jsx
@@ -23,9 +23,14 @@ const LocationsPage = () => {
     queryFn: () => services.locations.getLocations(),
   });
 
-  const tableHeaders = ['Name', 'Address', 'Actions'];
+  const tableHeaders = [
+    { id: 'name', label: 'Name' },
+    { id: 'address', label: 'Address' },
+    { id: 'actions', label: 'Actions' },
+  ];
 
   const tableData = locations.map(location => ({
+    id: location.id,
     name: location.name,
     address: location.address,
     actions: (

--- a/src/pages/suppliers/SuppliersPage.jsx
+++ b/src/pages/suppliers/SuppliersPage.jsx
@@ -88,9 +88,15 @@ const SuppliersPage = () => {
     document.body.removeChild(link);
   };
 
-  const tableHeaders = ['Name', 'Contact Person', 'Email', 'Actions'];
+  const tableHeaders = [
+    { id: 'name', label: 'Name' },
+    { id: 'contact', label: 'Contact Person' },
+    { id: 'email', label: 'Email' },
+    { id: 'actions', label: 'Actions' },
+  ];
 
   const tableData = suppliers?.map(s => ({
+    id: s.id,
     name: s.name,
     contact: s.contact,
     email: s.email,


### PR DESCRIPTION
This commit extends the previous fix to all pages that use the `MuiTable` component. The `tableHeaders` prop is now correctly configured as an array of objects with `id` and `label` properties, and the `tableData` prop now includes a unique `id` for each row.

This change ensures that the "unique key" warning is resolved throughout the application.

The following pages have been updated:
- `src/pages/billing/BillingPage.jsx`
- `src/pages/customers/CustomersPage.jsx`
- `src/pages/orders/PurchaseOrdersPage.jsx`
- `src/pages/reports/StockExpiryReport.jsx`
- `src/pages/sales/SalesOrdersPage.jsx`
- `src/pages/settings/LocationsPage.jsx`
- `src/pages/suppliers/SuppliersPage.jsx`