### PR TITLE
feat: Add voice recognition for product creation

### DIFF
--- a/src/components/ui/VoiceRecognition.jsx
+++ b/src/components/ui/VoiceRecognition.jsx
@@ -1,0 +1,102 @@
+import React, { useState, useEffect, useCallback } from 'react';
+import IconButton from '@mui/material/IconButton';
+import MicIcon from '@mui/icons-material/Mic';
+import MicOffIcon from '@mui/icons-material/MicOff';
+import { Tooltip } from '@mui/material';
+
+const VoiceRecognition = ({ onResult, onStateChange }) => {
+  const [isListening, setIsListening] = useState(false);
+  const [recognition, setRecognition] = useState(null);
+
+  useEffect(() => {
+    const SpeechRecognition = window.SpeechRecognition || window.webkitSpeechRecognition;
+    if (SpeechRecognition) {
+      const recognitionInstance = new SpeechRecognition();
+      recognitionInstance.continuous = false;
+      recognitionInstance.interimResults = false;
+      recognitionInstance.lang = 'en-US';
+      setRecognition(recognitionInstance);
+    }
+  }, []);
+
+  const stopListening = useCallback(() => {
+    if (recognition) {
+      recognition.stop();
+    }
+    setIsListening(false);
+    if (onStateChange) {
+      onStateChange('idle');
+    }
+  }, [recognition, onStateChange]);
+
+  useEffect(() => {
+    if (!recognition) return;
+
+    const handleResult = (event) => {
+      const transcript = event.results[0][0].transcript;
+      onResult(transcript);
+      stopListening();
+    };
+
+    const handleError = (event) => {
+      console.error('Speech recognition error', event.error);
+      stopListening();
+    };
+
+    const handleEnd = () => {
+      if (isListening) {
+        stopListening();
+      }
+    };
+
+    recognition.onresult = handleResult;
+    recognition.onerror = handleError;
+    recognition.onend = handleEnd;
+
+    return () => {
+      recognition.onresult = null;
+      recognition.onerror = null;
+      recognition.onend = null;
+    };
+  }, [recognition, isListening, onResult, stopListening]);
+
+  const startListening = () => {
+    if (recognition) {
+      setIsListening(true);
+      if (onStateChange) {
+        onStateChange('listening');
+      }
+      recognition.start();
+    }
+  };
+
+  const handleMicClick = () => {
+    if (isListening) {
+      stopListening();
+    } else {
+      startListening();
+    }
+  };
+
+  if (!recognition) {
+    return (
+      <Tooltip title="Voice recognition not supported in this browser">
+        <span>
+          <IconButton disabled>
+            <MicOffIcon />
+          </IconButton>
+        </span>
+      </Tooltip>
+    );
+  }
+
+  return (
+    <Tooltip title={isListening ? 'Stop listening' : 'Start listening'}>
+      <IconButton onClick={handleMicClick} color={isListening ? 'secondary' : 'default'}>
+        {isListening ? <MicOffIcon /> : <MicIcon />}
+      </IconButton>
+    </Tooltip>
+  );
+};
+
+export default VoiceRecognition;

--- a/src/pages/products/AddEditProductForm.jsx
+++ b/src/pages/products/AddEditProductForm.jsx
@@ -12,6 +12,9 @@ import Select from '@mui/material/Select';
 import MenuItem from '@mui/material/MenuItem';
 import FormControl from '@mui/material/FormControl';
 import InputLabel from '@mui/material/InputLabel';
+import InputAdornment from '@mui/material/InputAdornment';
+import Typography from '@mui/material/Typography';
+import VoiceRecognition from '../../components/ui/VoiceRecognition';
 
 const AddEditProductForm = ({
   onClose,
@@ -22,6 +25,7 @@ const AddEditProductForm = ({
   const { mode, services } = useApi();
   const a_services = { ...services, locations: locationService[mode] };
 
+  const [voiceState, setVoiceState] = useState('idle');
 
   const [formData, setFormData] = useState({
     name: '',
@@ -129,7 +133,33 @@ const AddEditProductForm = ({
 
   return (
     <Box component="form" onSubmit={handleSubmit}>
-      <TextField margin="dense" id="name" name="name" label="Product Name" type="text" fullWidth variant="standard" value={formData.name} onChange={handleChange} required />
+      <TextField
+        margin="dense"
+        id="name"
+        name="name"
+        label="Product Name"
+        type="text"
+        fullWidth
+        variant="standard"
+        value={formData.name}
+        onChange={handleChange}
+        required
+        InputProps={{
+          endAdornment: (
+            <InputAdornment position="end">
+              <VoiceRecognition
+                onResult={(transcript) => setFormData((prev) => ({ ...prev, name: transcript }))}
+                onStateChange={setVoiceState}
+              />
+            </InputAdornment>
+          ),
+        }}
+      />
+      {voiceState === 'listening' && (
+        <Typography variant="caption" color="secondary">
+          Listening... Speak now.
+        </Typography>
+      )}
       <TextField margin="dense" id="sku" name="sku" label="SKU" type="text" fullWidth variant="standard" value={formData.sku} onChange={handleChange} required />
       <TextField margin="dense" id="barcode" name="barcode" label="Barcode" type="text" fullWidth variant="standard" value={formData.barcode} onChange={handleChange} />
       <TextField margin="dense"id="category" name="category" label="Category" type="text" fullWidth variant="standard" value={formData.category} onChange={handleChange} required />


### PR DESCRIPTION
This commit introduces a new feature that allows users to add products by speaking into a microphone.

A new `VoiceRecognition` component has been created that uses the Web Speech API to capture and transcribe voice input. This component is integrated into the "Add New Product" form, providing a microphone icon in the "Product Name" field.

When the user clicks the microphone icon, the browser will listen for their voice, transcribe the input, and populate the "Product Name" field with the result.