### PR TITLE
feat: Allow creating a new customer from the sales order form

### DIFF
--- a/src/pages/customers/AddEditCustomerForm.jsx
+++ b/src/pages/customers/AddEditCustomerForm.jsx
@@ -37,10 +37,10 @@ const AddEditCustomerForm = ({ onClose, customer }) => {
     mutationFn: isEditMode
       ? (updatedCustomer) => services.customers.updateCustomer(customer.id, updatedCustomer)
       : services.customers.addCustomer,
-    onSuccess: () => {
+    onSuccess: (data) => {
       queryClient.invalidateQueries({ queryKey: ['customers'] });
       showNotification(`Customer ${isEditMode ? 'updated' : 'added'} successfully`, 'success');
-      onClose();
+      onClose(isEditMode ? null : data); // Pass back the new customer data on creation
     },
     onError: (err) => {
       showNotification(`Error: ${err.message}`, 'error');


### PR DESCRIPTION
This commit introduces the ability for users to create a new customer directly from the 'Create New Sales Order' page.

- An 'Add Customer' icon button has been added next to the customer selection dropdown in the `AddEditSOForm` component.
- Clicking this button opens a dialog containing the `AddEditCustomerForm`.
- Upon successful creation of a new customer, the customer list is automatically refreshed, and the new customer is selected in the dropdown.
- The `AddEditCustomerForm` has been slightly modified to pass the newly created customer's data back to the parent component.