### PR TITLE
fix: Add validation for missing stock location ID

### DIFF
--- a/src/pages/sales/AddEditSOForm.jsx
+++ b/src/pages/sales/AddEditSOForm.jsx
@@ -128,8 +128,10 @@ const AddEditSOForm = ({ open, onClose, so }) => {
       try {
         await Promise.all(items.map(item => {
           const product = products.find(p => p.id === item.productId);
-          // Find a location that can fulfill the ordered quantity
-          const stockLocation = product?.stockByLocation?.find(sl => sl.quantity >= item.quantity);
+          // Find a location that has a valid ID and can fulfill the ordered quantity
+          const stockLocation = product?.stockByLocation?.find(
+            sl => sl.locationId && sl.quantity >= item.quantity
+          );
 
           if (!stockLocation) {
             throw new Error(`Not enough stock for ${item.productName}. Required: ${item.quantity}, but no single location has this amount.`);


### PR DESCRIPTION
This commit makes the stock adjustment logic more robust by handling cases where a stock record might be missing a `locationId`.

The code now explicitly checks for the existence of `locationId` when searching for a suitable location to fulfill a sales order. This prevents errors when processing malformed stock data and ensures that stock is only deducted from valid, known locations.