### PR TITLE
feat: Add smart voice and input mode selection for product creation

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -19,7 +19,6 @@
         "@tanstack/react-query": "^5.45.1",
         "@zxing/library": "^0.21.0",
         "axios": "^1.7.2",
-        "compromise": "^14.14.4",
         "framer-motion": "^11.0.14",
         "jspdf": "^3.0.1",
         "jspdf-autotable": "^5.0.2",
@@ -2664,20 +2663,6 @@
         "node": ">= 0.8"
       }
     },
-    "node_modules/compromise": {
-      "version": "14.14.4",
-      "resolved": "https://registry.npmjs.org/compromise/-/compromise-14.14.4.tgz",
-      "integrity": "sha512-QdbJwronwxeqb7a5KFK/+Y5YieZ4PE1f7ai0vU58Pp4jih+soDCBMuKVbhDEPQ+6+vI3vSiG4UAAjTAXLJw1Qw==",
-      "license": "MIT",
-      "dependencies": {
-        "efrt": "2.7.0",
-        "grad-school": "0.0.5",
-        "suffix-thumb": "5.0.2"
-      },
-      "engines": {
-        "node": ">=12.0.0"
-      }
-    },
     "node_modules/concat-map": {
       "version": "0.0.1",
       "resolved": "https://registry.npmjs.org/concat-map/-/concat-map-0.0.1.tgz",
@@ -2983,15 +2968,6 @@
       },
       "engines": {
         "node": ">= 0.4"
-      }
-    },
-    "node_modules/efrt": {
-      "version": "2.7.0",
-      "resolved": "https://registry.npmjs.org/efrt/-/efrt-2.7.0.tgz",
-      "integrity": "sha512-/RInbCy1d4P6Zdfa+TMVsf/ufZVotat5hCw3QXmWtjU+3pFEOvOQ7ibo3aIxyCJw2leIeAMjmPj+1SLJiCpdrQ==",
-      "license": "MIT",
-      "engines": {
-        "node": ">=12.0.0"
       }
     },
     "node_modules/electron-to-chromium": {
@@ -3605,15 +3581,6 @@
       },
       "funding": {
         "url": "https://github.com/sponsors/ljharb"
-      }
-    },
-    "node_modules/grad-school": {
-      "version": "0.0.5",
-      "resolved": "https://registry.npmjs.org/grad-school/-/grad-school-0.0.5.tgz",
-      "integrity": "sha512-rXunEHF9M9EkMydTBux7+IryYXEZinRk6g8OBOGDBzo/qWJjhTxy86i5q7lQYpCLHN8Sqv1XX3OIOc7ka2gtvQ==",
-      "license": "MIT",
-      "engines": {
-        "node": ">=8.0.0"
       }
     },
     "node_modules/has-flag": {
@@ -4901,12 +4868,6 @@
       "version": "4.2.0",
       "resolved": "https://registry.npmjs.org/stylis/-/stylis-4.2.0.tgz",
       "integrity": "sha512-Orov6g6BB1sDfYgzWfTHDOxamtX1bE/zo104Dh9e6fqJ3PooipYyfJ0pUmrZO2wAvO8YbEyeFrkV91XTsGMSrw==",
-      "license": "MIT"
-    },
-    "node_modules/suffix-thumb": {
-      "version": "5.0.2",
-      "resolved": "https://registry.npmjs.org/suffix-thumb/-/suffix-thumb-5.0.2.tgz",
-      "integrity": "sha512-I5PWXAFKx3FYnI9a+dQMWNqTxoRt6vdBdb0O+BJ1sxXCWtSoQCusc13E58f+9p4MYx/qCnEMkD5jac6K2j3dgA==",
       "license": "MIT"
     },
     "node_modules/supports-color": {

--- a/package.json
+++ b/package.json
@@ -22,7 +22,6 @@
     "@tanstack/react-query": "^5.45.1",
     "@zxing/library": "^0.21.0",
     "axios": "^1.7.2",
-    "compromise": "^14.14.4",
     "framer-motion": "^11.0.14",
     "jspdf": "^3.0.1",
     "jspdf-autotable": "^5.0.2",

--- a/src/pages/products/AddEditProductForm.jsx
+++ b/src/pages/products/AddEditProductForm.jsx
@@ -159,6 +159,7 @@ const AddEditProductForm = ({
         id="name"
         name="name"
         label="Product Name"
+        inputProps={{ 'data-testid': 'name-input' }}
         type="text"
         fullWidth
         variant="standard"
@@ -186,6 +187,7 @@ const AddEditProductForm = ({
         id="sku"
         name="sku"
         label="SKU"
+        inputProps={{ 'data-testid': 'sku-input' }}
         type="text"
         fullWidth
         variant="standard"
@@ -208,6 +210,7 @@ const AddEditProductForm = ({
         id="barcode"
         name="barcode"
         label="Barcode"
+        inputProps={{ 'data-testid': 'barcode-input' }}
         type="text"
         fullWidth
         variant="standard"
@@ -229,6 +232,7 @@ const AddEditProductForm = ({
         id="category"
         name="category"
         label="Category"
+        inputProps={{ 'data-testid': 'category-input' }}
         type="text"
         fullWidth
         variant="standard"
@@ -246,14 +250,15 @@ const AddEditProductForm = ({
           ),
         }}
       />
-      <TextField margin="dense" id="price" name="price" label="Price" type="number" fullWidth variant="standard" value={formData.price} onChange={handleChange} required />
-      <TextField margin="dense" id="costPrice" name="costPrice" label="Cost Price" type="number" fullWidth variant="standard" value={formData.costPrice} onChange={handleChange} required />
-      <TextField margin="dense" id="lowStockThreshold" name="lowStockThreshold" label="Low Stock Threshold" type="number" fullWidth variant="standard" value={formData.lowStockThreshold} onChange={handleChange} required />
+      <TextField margin="dense" id="price" name="price" label="Price" type="number" fullWidth variant="standard" value={formData.price} onChange={handleChange} required inputProps={{ 'data-testid': 'price-input' }} />
+      <TextField margin="dense" id="costPrice" name="costPrice" label="Cost Price" type="number" fullWidth variant="standard" value={formData.costPrice} onChange={handleChange} required inputProps={{ 'data-testid': 'costPrice-input' }} />
+      <TextField margin="dense" id="lowStockThreshold" name="lowStockThreshold" label="Low Stock Threshold" type="number" fullWidth variant="standard" value={formData.lowStockThreshold} onChange={handleChange} required inputProps={{ 'data-testid': 'lowStockThreshold-input' }} />
       <TextField
         margin="dense"
         id="imageUrl"
         name="imageUrl"
         label="Image URL"
+        inputProps={{ 'data-testid': 'imageUrl-input' }}
         type="text"
         fullWidth
         variant="standard"
@@ -273,7 +278,7 @@ const AddEditProductForm = ({
 
       {!isEditMode && (
         <>
-          <TextField margin="dense" id="stock" name="stock" label="Initial Stock" type="number" fullWidth variant="standard" value={formData.stock} onChange={handleChange} />
+          <TextField margin="dense" id="stock" name="stock" label="Initial Stock" type="number" fullWidth variant="standard" value={formData.stock} onChange={handleChange} inputProps={{ 'data-testid': 'stock-input' }} />
           <FormControl fullWidth margin="dense" variant="standard" disabled={!formData.stock || formData.stock <= 0}>
             <InputLabel id="location-select-label">Location for Initial Stock</InputLabel>
             <Select
@@ -296,6 +301,7 @@ const AddEditProductForm = ({
             id="batchNumber"
             name="batchNumber"
             label="Batch Number"
+            inputProps={{ 'data-testid': 'batchNumber-input' }}
             type="text"
             fullWidth
             variant="standard"


### PR DESCRIPTION
This commit enhances the voice input feature by adding a "Smart Voice Add" mode and an input mode selector.

- A new `SmartVoiceAdd` component is introduced, which uses the Web Speech API to capture and transcribe voice input. It then uses regular expressions to parse the transcript and extract product details, which are used to populate the form fields.
- A dropdown menu has been added to the "Add New Product" form, allowing users to switch between "Manual Entry", "Voice per Field", and "Smart Voice Add" modes.
- The UI is now conditionally rendered based on the selected input mode.
- The `VoiceRecognition` component has been refactored to be more robust.
- The `compromise` dependency has been removed as it was not used in the final implementation.