### PR TITLE
Fix: Initial stock not being saved when adding a product

### DIFF
--- a/jules-scratch/verification/verify_add_product_stock.py
+++ b/jules-scratch/verification/verify_add_product_stock.py
@@ -1,0 +1,46 @@
+from playwright.sync_api import sync_playwright, expect
+import time
+
+def run(playwright):
+    browser = playwright.chromium.launch(headless=True)
+    context = browser.new_context()
+    page = context.new_page()
+
+    # Log in
+    page.goto("http://localhost:5173/login")
+    page.get_by_label("Email").fill("admin@example.com")
+    page.get_by_role("textbox", name="Password").fill("password")
+    page.get_by_role("button", name="Sign In", exact=True).click()
+    expect(page).to_have_url("http://localhost:5173/dashboard")
+
+    # Navigate to Products page
+    page.goto("http://localhost:5173/products")
+    page.get_by_role("button", name="Add Product").click()
+
+    # Fill out the form
+    product_name = f"Test Product {int(time.time())}"
+    page.get_by_label("Product Name").fill(product_name)
+    page.get_by_label("SKU").fill("TEST-SKU")
+    page.get_by_label("Category").fill("Test Category")
+    page.get_by_label("Price").fill("10")
+    page.get_by_label("Cost Price").fill("5")
+    page.get_by_label("Low Stock Threshold").fill("5")
+    page.get_by_label("Initial Stock").fill("100")
+    page.get_by_label("Batch Number").fill("B-TEST")
+    page.get_by_label("Expiry Date").fill("2025-12-31")
+
+    page.get_by_role("button", name="Add Product").click()
+
+    # Navigate to Stock page and verify
+    page.goto("http://localhost:5173/stock")
+
+    # Take a screenshot for visual confirmation
+    page.screenshot(path="jules-scratch/verification/stock_page_with_new_product.png")
+
+    # Assert that the new product is in the table with the correct stock
+    expect(page.locator(f'tr:has-text("{product_name}") td').nth(2)).to_have_text("100")
+
+    browser.close()
+
+with sync_playwright() as playwright:
+    run(playwright)

--- a/src/services/productService.js
+++ b/src/services/productService.js
@@ -16,7 +16,7 @@ const local = {
   },
   addProduct: async (productData) => {
     console.log('Adding product in local mode', productData);
-    const { stock, batchNumber, expiryDate, locationId, ...productDetails } = productData;
+    const { stock, batchNumber, expiryDate, ...productDetails } = productData;
 
     // 1. Create the product
     const productResponse = await fetch('/products', {
@@ -27,11 +27,10 @@ const local = {
     const newProduct = await productResponse.json();
 
     // 2. If initial stock is provided, create the stock entry
-    if (stock > 0 && locationId) {
+    if (stock > 0) {
       const newStockEntry = {
         productId: newProduct.id,
         quantity: stock,
-        locationId: parseInt(locationId),
         batches: [{
           batchNumber: batchNumber || `B${newProduct.id}-INIT`,
           expiryDate: expiryDate || new Date(new Date().setFullYear(new Date().getFullYear() + 1)).toISOString(), // Default 1 year expiry
@@ -70,18 +69,17 @@ const remote = {
   addProduct: async (productData) => {
     console.log('Adding product via API', productData);
     // Separate product details from stock details
-    const { stock, batchNumber, expiryDate, locationId, ...productDetails } = productData;
+    const { stock, batchNumber, expiryDate, ...productDetails } = productData;
 
     // 1. Create the product
     const productResponse = await api.post('/products', productDetails);
     const newProduct = productResponse.data;
 
     // 2. If initial stock is provided, create the stock entry
-    if (stock > 0 && expiryDate && locationId) { // Ensure all stock details are present
+    if (stock > 0 && expiryDate) { // Ensure all stock details are present
       const newStockEntry = {
         productId: newProduct.id,
         quantity: stock,
-        locationId: locationId,
         batches: [{
           batchNumber: batchNumber || `B${newProduct.id}-INIT`,
           expiryDate: expiryDate,


### PR DESCRIPTION
This change fixes a bug where the initial stock value was not being saved when adding a new product. This was caused by the previous refactoring to remove the locations functionality. The `addProduct` function in the `productService.js` file was still expecting a `locationId`, which was no longer being provided. This change removes the dependency on `locationId` and ensures that the initial stock is created correctly.