### PR TITLE
feat(orders): Filter products by supplier and fix related bugs

### DIFF
--- a/src/pages/orders/AddEditPOForm.jsx
+++ b/src/pages/orders/AddEditPOForm.jsx
@@ -84,7 +84,7 @@ const AddEditPOForm = ({ open, onClose, po }) => {
     }
 
     const supplierProductIds = new Set(selectedSupplier.products);
-    return products.filter(p => supplierProductIds.has(p.id));
+    return products.filter(p => supplierProductIds.has(parseInt(p.id, 10)));
   }, [supplierId, suppliers, products]);
 
   const handleAddFromSuggestion = (product) => {


### PR DESCRIPTION
This commit enhances the new purchase order form and fixes related bugs.

Feature:
- The product selection dropdown is now dynamically filtered to only show products associated with the currently selected supplier.
- The list of chosen products is automatically reset when the supplier is changed to prevent invalid product-supplier combinations.

Bug Fixes:
- Corrects a bug where the product filtering failed due to a type mismatch when comparing product IDs. The comparison is now type-safe.
- Prevents a `TypeError` that occurred when submitting the form without a supplier selected by reordering validation logic to run before data is processed.