### PR TITLE
fix(voice): Correct guided voice input loop

### DIFF
--- a/src/components/ui/GuidedVoiceAdd.jsx
+++ b/src/components/ui/GuidedVoiceAdd.jsx
@@ -106,10 +106,11 @@ const GuidedVoiceAdd = ({ fields, onUpdate, onComplete, start }) => {
     if (status === 'speaking' || status === 'listening') {
       processField();
     }
-  }, [currentFieldIndex, status, processField]);
+  }, [currentFieldIndex, processField]);
 
 
   const handleStart = () => {
+    window.speechSynthesis.cancel();
     setCurrentFieldIndex(0);
     processField();
   };


### PR DESCRIPTION
- The guided voice input feature was stuck in a loop, causing it to re-speak prompts instead of listening for user input. This was due to the status change from 'speaking' to 'listening' incorrectly re-triggering the effect that processes the current field.
- The `status` dependency has been removed from the `useEffect` hook that orchestrates the voice input flow, ensuring it only triggers when the field index changes.
- Added `window.speechSynthesis.cancel()` to the start of the process to clear any lingering speech tasks from previous sessions.