### PR TITLE
fix: Ensure new stock batches are created correctly

### DIFF
--- a/src/pages/stock/AddStockForm.jsx
+++ b/src/pages/stock/AddStockForm.jsx
@@ -30,7 +30,7 @@ const AddStockForm = ({ onClose }) => {
   });
 
   const mutation = useMutation({
-    mutationFn: services.stock.adjustStockLevel,
+    mutationFn: services.stock.addStock,
     onSuccess: () => {
       queryClient.invalidateQueries({ queryKey: ['stock'] });
       showNotification('Stock added successfully', 'success');

--- a/src/services/stockService.js
+++ b/src/services/stockService.js
@@ -110,6 +110,24 @@ const local = {
     });
     return await putRes.json();
   },
+  addStock: async ({ productId, quantity, batchNumber, expiryDate }) => {
+    console.log('Adding new stock batch in local mode', { productId, quantity, batchNumber, expiryDate });
+    const newStockEntry = {
+      productId,
+      quantity,
+      batches: [{ batchNumber, expiryDate, quantity }]
+    };
+    const response = await fetch('/stock', {
+      method: 'POST',
+      headers: { 'Content-Type': 'application/json' },
+      body: JSON.stringify(newStockEntry)
+    });
+    if (!response.ok) {
+        const errorBody = await response.text();
+        throw new Error(`Failed to add stock: ${errorBody}`);
+    }
+    return await response.json();
+  },
   getProductWithStock: async (id) => {
     console.log(`Fetching product ${id} with stock from local db.json`);
     const response = await fetch('/db.json');
@@ -215,7 +233,15 @@ const remote = {
     stockEntry.quantity = stockEntry.batches.reduce((sum, b) => sum + b.quantity, 0);
     return await api.put(`/stock/${stockEntry.productId}`, stockEntry);
   },
-
+  addStock: async ({ productId, quantity, batchNumber, expiryDate }) => {
+    console.log('Adding new stock batch via API', { productId, quantity, batchNumber, expiryDate });
+    const newStockEntry = {
+      productId,
+      quantity,
+      batches: [{ batchNumber, expiryDate, quantity }]
+    };
+    return await api.post('/stock', newStockEntry);
+  },
   getProductWithStock: async (id) => {
     console.log(`Fetching product ${id} with stock from API`);
     const [productResponse, stockResponse] = await Promise.all([


### PR DESCRIPTION
This commit fixes a bug where adding a new stock batch for a product that already had stock would not create a new, separate stock entry.

The `adjustStockLevel` function was incorrectly being used for both adding and adjusting stock, and it would only ever modify the first stock entry it found for a given product.

The fix involves:
1.  Creating a new, dedicated `addStock` function in `stockService.js` that always creates a new stock entry via a POST request.
2.  Updating `AddStockForm.jsx` to use this new `addStock` function.

This change ensures that the "Add Stock" form now correctly creates a new stock record for each new batch, resolving the bug reported by the user.