### PR TITLE
fix: Correctly call product service in AddStockForm

### DIFF
--- a/src/pages/stock/AddStockForm.jsx
+++ b/src/pages/stock/AddStockForm.jsx
@@ -26,7 +26,7 @@ const AddStockForm = ({ onClose }) => {
 
   const { data: products = [], isLoading: isLoadingProducts, isError, error } = useQuery({
     queryKey: ['products', mode],
-    queryFn: () => services.product.getProducts(),
+    queryFn: () => services.products.getProducts(),
   });
 
   const mutation = useMutation({


### PR DESCRIPTION
Resolves a crash on the stock page when clicking "Add Stock". The `AddStockForm` component was attempting to call `services.product.getProducts()`, but the service is registered as `services.products`.

This commit corrects the function call to use the proper service name, `services.products`, which resolves the "Cannot read properties of undefined (reading 'getProducts')" error.