### PR TITLE
fix: Correctly save sizes for new products

### DIFF
--- a/jules-scratch/verification/verify_new_product_stock.py
+++ b/jules-scratch/verification/verify_new_product_stock.py
@@ -1,0 +1,55 @@
+from playwright.sync_api import sync_playwright, expect
+import time
+
+def run(playwright):
+    browser = playwright.chromium.launch(headless=True)
+    context = browser.new_context()
+    page = context.new_page()
+
+    # Login
+    page.goto("http://localhost:5173/login", wait_until="load")
+    page.get_by_label("Email").fill("admin@example.com")
+    page.get_by_label("Password", exact=True).fill("password")
+    page.get_by_role("button", name="Login").click()
+    expect(page).to_have_url("http://localhost:5173/dashboard")
+
+    # Create a new product
+    page.goto("http://localhost:5173/products")
+    page.get_by_role("button", name="Add Product").click()
+
+    product_name = f"Test Product {int(time.time())}"
+    page.get_by_label("Product Name").fill(product_name)
+    page.get_by_label("SKU").fill(f"TP-{int(time.time())}")
+    page.get_by_label("Category").fill("Test Category")
+    page.get_by_label("Cost Price").fill("10")
+    page.get_by_label("Selling Price").fill("20")
+    page.get_by_label("Low Stock Threshold").fill("5")
+
+    page.get_by_role("button", name="Add Product").click()
+    page.wait_for_timeout(1000) # wait for UI to update
+
+    # Go to stock page
+    page.goto("http://localhost:5173/stock")
+    expect(page).to_have_url("http://localhost:5173/stock")
+
+    # Add stock to the new product
+    page.get_by_role("button", name="Add Stock").click()
+    page.get_by_label("Product").click()
+    page.get_by_role("option", name=product_name).click()
+    page.get_by_label("Size 6").fill("5")
+    page.get_by_label("Size 7").fill("5")
+    page.get_by_label("Size 8").fill("5")
+    page.get_by_label("Size 9").fill("5")
+    page.get_by_role("button", name="Add Stock").click()
+    page.wait_for_timeout(1000) # wait for UI to update
+
+    # Verify stock was added
+    expect(page.locator(f"text={product_name}")).to_be_visible()
+
+    # Take screenshot
+    page.screenshot(path="jules-scratch/verification/new_product_stock.png")
+
+    browser.close()
+
+with sync_playwright() as playwright:
+    run(playwright)

--- a/src/pages/products/AddEditProductForm.jsx
+++ b/src/pages/products/AddEditProductForm.jsx
@@ -232,6 +232,7 @@ const AddEditProductForm = ({
       discountedPrice: parseFloat(formData.discountedPrice) || 0,
       lowStockThreshold: parseInt(formData.lowStockThreshold, 10) || 0,
       stock: totalStock,
+      sizes: formData.sizes.map(s => ({ size: s.size, quantity: 0 })),
     };
     if (isEditMode) {
       delete submissionData.stock;

--- a/src/services/stockService.js
+++ b/src/services/stockService.js
@@ -123,6 +123,9 @@ const local = {
       stockEntry.batches.push({ batchNumber, expiryDate, quantity, sizes, createdDate });
 
       // Update sizes
+      if (!stockEntry.sizes) {
+        stockEntry.sizes = [];
+      }
       sizes.forEach(size => {
         const existingSize = stockEntry.sizes.find(s => s.size === size.size);
         if (existingSize) {
@@ -271,6 +274,9 @@ const remote = {
       stockEntry.batches.push({ batchNumber, expiryDate, quantity, sizes, createdDate });
 
       // Update sizes
+      if (!stockEntry.sizes) {
+        stockEntry.sizes = [];
+      }
       sizes.forEach(size => {
         const existingSize = stockEntry.sizes.find(s => s.size === size.size);
         if (existingSize) {


### PR DESCRIPTION
This commit fixes a bug that occurred when adding stock to a newly created product.

- The `AddEditProductForm.jsx` has been updated to ensure that the `sizes` array is correctly initialized and saved with a quantity of 0 for each size when a new product is created.
- A defensive check has also been added to `stockService.js` to prevent errors if a stock entry is missing the `sizes` property.