### PR TITLE
feat: Add validation and enhance size management in stock forms

### DIFF
--- a/src/pages/stock/AddStockForm.jsx
+++ b/src/pages/stock/AddStockForm.jsx
@@ -87,16 +87,13 @@ const AddStockForm = ({ onClose }) => {
   useEffect(() => {
     const product = products.find((p) => p.id === productId);
     setSelectedProduct(product);
+    setSizes([]); // Reset sizes when product changes
     if (product) {
       if (product.sizeProfile) {
         handleSizePresetChange(product.sizeProfile);
       } else if (product.sizes) {
         setSizes(product.sizes.map(s => ({ ...s, quantity: 1 })));
-      } else {
-        setSizes([]);
       }
-    } else {
-      setSizes([]);
     }
 
     const nextYear = new Date();
@@ -238,8 +235,8 @@ const AddStockForm = ({ onClose }) => {
                 </IconButton>
               </Box>
             ))}
-            <Button onClick={handleAddSize} variant="outlined" sx={{ mt: 1 }}>
-              Add Size
+            <Button onClick={handleAddSize} variant="contained" color="primary" sx={{ mt: 1 }}>
+              Add Another Size
             </Button>
         </Box>
       )}


### PR DESCRIPTION
This commit introduces two main improvements to the stock management forms:

1.  **Stock Removal Validation:**
    - The `StockAdjustmentForm` now includes client-side validation to prevent removing more stock of a specific size than is available. An error notification is shown if the user attempts to do so.

2.  **Enhanced 'Add Stock' Form:**
    - The `AddStockForm` now resets the sizes when a new product is selected, preventing size information from carrying over between different products.
    - The 'Add Size' button has been made more prominent to improve user experience.