### PR TITLE
fix: Ensure batch.sizes is initialized before adding new sizes

### DIFF
--- a/src/services/stockService.js
+++ b/src/services/stockService.js
@@ -82,6 +82,9 @@ const local = {
 
     if (sizes && sizes.length > 0) {
       // Size-specific adjustment
+      if (!batch.sizes) {
+        batch.sizes = [];
+      }
       sizes.forEach(adj => {
         const sizeIndex = batch.sizes.findIndex(s => s.size === adj.size);
         if (sizeIndex > -1) {


### PR DESCRIPTION
This commit fixes a bug where adding a new size to a batch that had no previous sizes would fail. The `adjustStockLevel` function in the `stockService` now ensures that the `sizes` array is initialized on a batch before attempting to add new sizes to it.