### PR TITLE
Fix 404 error when adding stock to a new product

### DIFF
--- a/src/services/stockService.js
+++ b/src/services/stockService.js
@@ -311,8 +311,19 @@ const remote = {
   addStock: async ({ productId, supplierId, quantity, batchNumber, expiryDate, sizes, createdDate }) => {
     console.log('Adding new stock batch via API', { productId, supplierId, quantity, batchNumber, expiryDate, sizes, createdDate });
 
-    const stockRes = await api.get(`/stock/${productId}`);
-    let stockEntry = stockRes.data;
+    let stockEntry;
+    try {
+      const stockRes = await api.get(`/stock/${productId}`);
+      stockEntry = stockRes.data;
+    } catch (error) {
+      if (error.response && error.response.status === 404) {
+        console.log(`Stock entry for product ${productId} not found. Creating a new one.`);
+        stockEntry = null;
+      } else {
+        // Re-throw other errors
+        throw error;
+      }
+    }
 
     if (stockEntry) {
       stockEntry.quantity += quantity;


### PR DESCRIPTION
When creating a new product with an initial stock quantity, the application would attempt to fetch the stock entry before it was created. This resulted in a 404 Not Found error from the API, causing the entire operation to fail.

This change modifies the `stockService` to gracefully handle this 404 error. It now wraps the stock fetch call in a `try...catch` block. If a 404 is caught, it assumes the stock entry does not exist and proceeds to create a new one, preventing the crash and allowing the product and stock to be created successfully.