### PR TITLE
feat: Add size selection to sales orders

### DIFF
--- a/jules-scratch/verification/verify_so_size_selection.py
+++ b/jules-scratch/verification/verify_so_size_selection.py
@@ -1,0 +1,41 @@
+from playwright.sync_api import sync_playwright
+
+def run(playwright):
+    browser = playwright.chromium.launch(headless=True)
+    context = browser.new_context()
+    page = context.new_page()
+
+    try:
+        page.goto("http://localhost:5173/")
+
+        # Click on the "Sales" link in the sidebar
+        page.wait_for_selector('a[href="/sales/orders"]', timeout=60000)
+        page.locator('a[href="/sales/orders"]').click()
+
+        # Click the "Create New Sales Order" button
+        page.wait_for_selector('button:has-text("New Sales Order")', timeout=60000)
+        page.locator('button:has-text("New Sales Order")').click()
+
+        # Select a customer
+        page.wait_for_selector('label:has-text("Customer") + div', timeout=60000)
+        page.locator('label:has-text("Customer") + div').click()
+        page.locator('li[data-value="1"]').click()
+
+        # Select a product
+        page.locator('label:has-text("Product") + div').first.click()
+        page.locator('li[data-value="1"]').click() # Wireless Mouse
+
+        # Select a size
+        page.locator('label:has-text("Size") + div').first.click()
+        page.locator('li[data-value="M"]').click()
+
+        # Enter quantity
+        page.locator('label:has-text("Quantity") + div input').first.fill("2")
+
+        page.screenshot(path="jules-scratch/verification/verification.png")
+
+    finally:
+        browser.close()
+
+with sync_playwright() as playwright:
+    run(playwright)

--- a/src/pages/sales/AddEditSOForm.jsx
+++ b/src/pages/sales/AddEditSOForm.jsx
@@ -28,7 +28,7 @@ const AddEditSOForm = ({ open, onClose, so }) => {
   const { addNotification } = useNotificationCenter();
 
   const [customerId, setCustomerId] = useState('');
-  const [productsList, setProductsList] = useState([{ productId: '', quantity: 1 }]);
+  const [productsList, setProductsList] = useState([{ productId: '', quantity: 1, size: '' }]);
   const [status, setStatus] = useState('Pending');
   const [isAddCustomerOpen, setAddCustomerOpen] = useState(false);
 
@@ -36,11 +36,11 @@ const AddEditSOForm = ({ open, onClose, so }) => {
     if (open) {
       if (isEditMode && so) {
         setCustomerId(so.customerId || '');
-        setProductsList(so.items.map(p => ({ productId: p.productId, quantity: p.quantity })));
+        setProductsList(so.items.map(p => ({ productId: p.productId, quantity: p.quantity, size: p.size || '' })));
         setStatus(so.status || 'Pending');
       } else {
         setCustomerId('');
-        setProductsList([{ productId: '', quantity: 1 }]);
+        setProductsList([{ productId: '', quantity: 1, size: '' }]);
         setStatus('Pending');
       }
     }
@@ -80,10 +80,16 @@ const AddEditSOForm = ({ open, onClose, so }) => {
   const handleProductChange = (index, field, value) => {
     const newProducts = [...productsList];
     newProducts[index][field] = value;
+
+    if (field === 'productId') {
+      const product = products.find(p => p.id === value);
+      const availableSizes = product?.sizes?.filter(s => s.quantity > 0) || [];
+      newProducts[index].size = availableSizes.length > 0 ? availableSizes[0].size : '';
+    }
     setProductsList(newProducts);
   };
 
-  const handleAddProduct = () => setProductsList([...productsList, { productId: '', quantity: 1 }]);
+  const handleAddProduct = () => setProductsList([...productsList, { productId: '', quantity: 1, size: '' }]);
 
   const handleRemoveProduct = (index) => {
     if (productsList.length > 1) {
@@ -99,14 +105,23 @@ const AddEditSOForm = ({ open, onClose, so }) => {
       return;
     }
 
+    if (productsList.some(p => {
+      const product = products.find(prod => prod.id === p.productId);
+      return product && product.sizes && product.sizes.length > 0 && !p.size;
+    })) {
+      showNotification('Please select a size for all products that require it.', 'warning');
+      return;
+    }
+
     const customer = customers?.find(c => c.id === customerId);
     const items = productsList.map(item => {
       const product = products.find(p => p.id === (item.productId));
       return {
         productId: (item.productId),
         productName: product?.name || '',
-        quantity: (item.quantity) || 0,
+        quantity: Number(item.quantity) || 0,
         price: product?.price || 0,
+        size: item.size,
       }
     }).filter(item => item.productId && item.quantity > 0);
 
@@ -127,22 +142,45 @@ const AddEditSOForm = ({ open, onClose, so }) => {
 
     if (soData.status === 'Completed' && (!isEditMode || (isEditMode && so.status !== 'Completed'))) {
       try {
-        await Promise.all(items.map(item => {
+        await Promise.all(items.map(async (item) => {
           const product = products.find(p => p.id === item.productId);
-          if (product.stock < item.quantity) {
-            throw new Error(`Not enough stock for ${item.productName}. Required: ${item.quantity}, Available: ${product.stock}`);
+          const stockAdjustments = [];
+          if (item.size) {
+            const sizeStock = product.sizes.find(s => s.size === item.size)?.quantity || 0;
+            if (sizeStock < item.quantity) {
+              throw new Error(`Not enough stock for ${item.productName} (Size: ${item.size}). Required: ${item.quantity}, Available: ${sizeStock}`);
+            }
+            // This is a placeholder for a real batch number. In a real app, this would be more sophisticated.
+            const batchNumber = product.batches.find(b => b.sizes.some(s => s.size === item.size && s.quantity > 0))?.batchNumber;
+            if (!batchNumber) {
+              throw new Error(`No batch found with available stock for ${item.productName} (Size: ${item.size})`);
+            }
+            stockAdjustments.push(stockService.adjustStockLevel({
+              productId: item.productId,
+              batchNumber,
+              sizes: [{ size: item.size, quantity: -item.quantity }],
+            }));
+          } else {
+            if (product.stock < item.quantity) {
+              throw new Error(`Not enough stock for ${item.productName}. Required: ${item.quantity}, Available: ${product.stock}`);
+            }
+            const batchNumber = product.batches.find(b => b.quantity > 0)?.batchNumber;
+             if (!batchNumber) {
+              throw new Error(`No batch found with available stock for ${item.productName}`);
+            }
+            stockAdjustments.push(stockService.adjustStockLevel({
+              productId: item.productId,
+              batchNumber,
+              quantity: -item.quantity,
+            }));
           }
-          return stockService.adjustStockLevel({
-            productId: item.productId,
-            quantity: -item.quantity,
-          });
+          return Promise.all(stockAdjustments);
         }));
 
-        // If all stock adjustments are successful, invalidate the query to refetch
         queryClient.invalidateQueries({ queryKey: ['stock'] });
       } catch (error) {
         showNotification(`Error adjusting stock: ${error.message}`, 'error');
-        return; // Stop the submission process if stock adjustment fails
+        return;
       }
     }
 
@@ -195,18 +233,39 @@ const AddEditSOForm = ({ open, onClose, so }) => {
         </FormControl>
 
         <Typography variant="h6" sx={{ mt: 2, mb: 1 }}>Products</Typography>
-        {productsList.map((productItem, index) => (
-          <Box key={index} sx={{ display: 'flex', alignItems: 'center', gap: 2, mb: 2 }}>
-            <FormControl sx={{ flex: 4 }} required>
-              <InputLabel>Product</InputLabel>
-              <Select value={productItem.productId} onChange={(e) => handleProductChange(index, 'productId', e.target.value)} label="Product">
-                {isLoadingProducts ? <CircularProgress size={24} /> : products?.map(p => <MenuItem key={p.id} value={p.id}>{p.name} (In Stock: {p.stock})</MenuItem>)}
-              </Select>
-            </FormControl>
-            <TextField label="Quantity" type="number" value={productItem.quantity} onChange={(e) => handleProductChange(index, 'quantity', e.target.value)} required sx={{ flex: 1 }} variant="outlined" margin="normal" InputProps={{ inputProps: { min: 1 } }} />
-            <IconButton onClick={() => handleRemoveProduct(index)} disabled={productsList.length === 1}><Delete /></IconButton>
-          </Box>
-        ))}
+        {productsList.map((productItem, index) => {
+          const selectedProduct = products?.find(p => p.id === productItem.productId);
+          const availableSizes = selectedProduct?.sizes?.filter(s => s.quantity > 0) || [];
+
+          return (
+            <Box key={index} sx={{ display: 'flex', alignItems: 'center', gap: 2, mb: 2 }}>
+              <FormControl sx={{ flex: 4 }} required>
+                <InputLabel>Product</InputLabel>
+                <Select value={productItem.productId} onChange={(e) => handleProductChange(index, 'productId', e.target.value)} label="Product">
+                  {isLoadingProducts ? <CircularProgress size={24} /> : products?.map(p => <MenuItem key={p.id} value={p.id}>{p.name} (In Stock: {p.stock})</MenuItem>)}
+                </Select>
+              </FormControl>
+
+              <FormControl sx={{ flex: 2 }} required disabled={availableSizes.length === 0}>
+                <InputLabel>Size</InputLabel>
+                <Select
+                  value={productItem.size}
+                  onChange={(e) => handleProductChange(index, 'size', e.target.value)}
+                  label="Size"
+                >
+                  {availableSizes.map(s => (
+                    <MenuItem key={s.size} value={s.size}>
+                      {s.size} (In Stock: {s.quantity})
+                    </MenuItem>
+                  ))}
+                </Select>
+              </FormControl>
+
+              <TextField label="Quantity" type="number" value={productItem.quantity} onChange={(e) => handleProductChange(index, 'quantity', e.target.value)} required sx={{ flex: 1 }} variant="outlined" margin="normal" InputProps={{ inputProps: { min: 1 } }} />
+              <IconButton onClick={() => handleRemoveProduct(index)} disabled={productsList.length === 1}><Delete /></IconButton>
+            </Box>
+          );
+        })}
         <Button startIcon={<Add />} onClick={handleAddProduct}>Add Product</Button>
 
         <Box sx={{ mt: 3, display: 'flex', justifyContent: 'flex-end', gap: 1 }}>

--- a/src/services/stockService.js
+++ b/src/services/stockService.js
@@ -28,6 +28,7 @@ const remote = {
           quantity: 0,
           batches: [],
           supplierIds: new Set(),
+          sizes: [],
         };
       }
       acc[item.productId].quantity += item.quantity;
@@ -35,11 +36,21 @@ const remote = {
       if (item.supplierId) {
         acc[item.productId].supplierIds.add(item.supplierId);
       }
+      if (item.sizes) {
+        item.sizes.forEach(size => {
+          const existingSize = acc[item.productId].sizes.find(s => s.size === size.size);
+          if (existingSize) {
+            existingSize.quantity += size.quantity;
+          } else {
+            acc[item.productId].sizes.push({ ...size });
+          }
+        });
+      }
       return acc;
     }, {});
 
     return products.map(product => {
-      const stockInfo = stockByProduct[product.id] || { quantity: 0, batches: [], supplierIds: new Set() };
+      const stockInfo = stockByProduct[product.id] || { quantity: 0, batches: [], supplierIds: new Set(), sizes: [] };
       const supplierNames = [...stockInfo.supplierIds].map(id => supplierMap.get(id) || 'N/A').join(', ');
 
       return {
@@ -47,6 +58,7 @@ const remote = {
         stock: stockInfo.quantity,
         batches: stockInfo.batches,
         supplierName: supplierNames,
+        sizes: stockInfo.sizes,
       };
     });
   },


### PR DESCRIPTION
This feature allows users to select a size for products when creating or editing a sales order.

- Updated the sales order form to include a size dropdown for products with available sizes.
- Modified the stock service to fetch and aggregate stock by size.
- Updated the sales order submission logic to include the selected size and adjust stock accordingly.