### PR TITLE
Fix: Correctly recalculate stock sizes on adjustment

### DIFF
--- a/src/services/stockService.js
+++ b/src/services/stockService.js
@@ -116,6 +116,22 @@ const remote = {
     stockEntry.batches = stockEntry.batches.filter(b => b.quantity > 0);
     stockEntry.quantity = stockEntry.batches.reduce((sum, b) => sum + b.quantity, 0);
 
+    // Recalculate sizes at the top-level stock entry
+    const newSizes = stockEntry.batches.reduce((acc, currentBatch) => {
+      if (currentBatch.sizes) {
+        currentBatch.sizes.forEach(sizeInfo => {
+          const existingSize = acc.find(s => s.size === sizeInfo.size);
+          if (existingSize) {
+            existingSize.quantity += sizeInfo.quantity;
+          } else {
+            acc.push({ size: sizeInfo.size, quantity: sizeInfo.quantity });
+          }
+        });
+      }
+      return acc;
+    }, []);
+    stockEntry.sizes = newSizes;
+
     return await api.put(`/stock/${productId}`, stockEntry);
   },
   addStock: async ({ productId, supplierId, quantity, batchNumber, expiryDate, sizes, createdDate }) => {


### PR DESCRIPTION
When adjusting stock for a product with sizes, the top-level `sizes` array was not being updated to reflect the changes made within the batches. This resulted in an incorrect representation of the size breakdown at the product level.

This commit fixes the issue by adding logic to the `adjustStockLevel` function in `stockService.js` to recalculate the top-level `sizes` array after any batch adjustments. The new logic iterates through all batches and aggregates the quantities for each size, ensuring the top-level `sizes` array is always in sync with the batch data.